### PR TITLE
Fix a bug with a version comparator for the risk calculator.

### DIFF
--- a/lib/package/audit/risk_calculator.rb
+++ b/lib/package/audit/risk_calculator.rb
@@ -39,7 +39,7 @@ module Package
         version_parts = @dependency.version.split('.').map(&:to_i)
         latest_version_parts = @dependency.latest_version.split('.').map(&:to_i)
 
-        if version_parts.first < latest_version_parts.first
+        if (version_parts.first || 0) < (latest_version_parts.first || 0)
           Risk.new(Enum::RiskType::MEDIUM, Enum::RiskExplanation::OUTDATED_BY_MAJOR_VERSION)
         elsif (version_parts <=> latest_version_parts) == -1
           Risk.new(Enum::RiskType::LOW, Enum::RiskExplanation::OUTDATED)

--- a/lib/package/audit/risk_calculator.rb
+++ b/lib/package/audit/risk_calculator.rb
@@ -36,9 +36,12 @@ module Package
       end
 
       def assess_version_risk
-        if (@dependency.version.split('.').first || '') < (@dependency.latest_version.split('.').first || '')
+        version_parts = @dependency.version.split('.').map(&:to_i)
+        latest_version_parts = @dependency.latest_version.split('.').map(&:to_i)
+
+        if version_parts.first < latest_version_parts.first
           Risk.new(Enum::RiskType::MEDIUM, Enum::RiskExplanation::OUTDATED_BY_MAJOR_VERSION)
-        elsif @dependency.version < @dependency.latest_version
+        elsif (version_parts <=> latest_version_parts) == -1
           Risk.new(Enum::RiskType::LOW, Enum::RiskExplanation::OUTDATED)
         else
           Risk.new(Enum::RiskType::NONE)


### PR DESCRIPTION
The risk calculator was incorrectly comparing versions by using string comparison, which caused it to think that 0.8.0 was more recent that 0.11.0. Now all comparisons are done using integers.