### PR TITLE
Add support for alternate formats of yarn.lock.

### DIFF
--- a/lib/package/audit/npm/yarn_lock_parser.rb
+++ b/lib/package/audit/npm/yarn_lock_parser.rb
@@ -3,7 +3,8 @@ module Package
     module Npm
       class YarnLockParser
         def initialize(yarn_lock_path)
-          @yarn_lock_path = File.read(yarn_lock_path)
+          @yarn_lock_file = File.read(yarn_lock_path)
+          @yarn_lock_path = yarn_lock_path
         end
 
         def fetch(default_deps, dev_deps)
@@ -22,17 +23,20 @@ module Package
 
         def fetch_package_block(dep_name, expected_version)
           regex = /#{Regexp.escape(dep_name)}@#{Regexp.escape(expected_version)}.*?:.*?(\n\n|\z)/m
-          blocks = @yarn_lock_path.match(regex)
+          blocks = @yarn_lock_file.match(regex)
           if blocks.nil? || blocks[0].nil?
-            raise NoMatchingPatternError, "Unable to find #{dep_name} in #{@yarn_lock_path}"
+            raise NoMatchingPatternError, "Unable to find \"#{dep_name}\" in #{@yarn_lock_path}"
           end
 
           blocks[0] || ''
         end
 
         def fetch_package_version(dep_name, pkg_block)
-          version = pkg_block.match(/version "(.*?)"/)&.[](1)
-          raise NoMatchingPatternError, "Unable to find #{dep_name} version in #{@yarn_lock_path}" if version.nil?
+          version = pkg_block.match(/version"?\s*"(.*?)"/)&.captures&.[](0)
+          if version.nil?
+            raise NoMatchingPatternError,
+                  "Unable to find the version of \"#{dep_name}\" in #{@yarn_lock_path}"
+          end
 
           version || '0.0.0.0'
         end

--- a/sig/package/audit/npm/yarn_lock_parser.rbs
+++ b/sig/package/audit/npm/yarn_lock_parser.rbs
@@ -2,6 +2,7 @@ module Package
   module Audit
     module Npm
       class YarnLockParser
+        @yarn_lock_file: String
         @yarn_lock_path: String
 
         def initialize: (String) -> void


### PR DESCRIPTION
When npm install is mistakenly used when yarn.lock exists, a slightly different type of yarn.lock may be generated, which couldn't be parsed by the previous version of the regex.