### PR TITLE
Fix a bug with regex used for parsing yarn.lock.

### DIFF
--- a/lib/package/audit/npm/yarn_lock_parser.rb
+++ b/lib/package/audit/npm/yarn_lock_parser.rb
@@ -22,7 +22,7 @@ module Package
         private
 
         def fetch_package_block(dep_name, expected_version)
-          regex = /#{Regexp.escape(dep_name)}@#{Regexp.escape(expected_version)}.*?:.*?(\n\n|\z)/m
+          regex = regex_pattern_for_package(dep_name, expected_version)
           blocks = @yarn_lock_file.match(regex)
           if blocks.nil? || blocks[0].nil?
             raise NoMatchingPatternError, "Unable to find \"#{dep_name}\" in #{@yarn_lock_path}"
@@ -39,6 +39,17 @@ module Package
           end
 
           version || '0.0.0.0'
+        end
+
+        def regex_pattern_for_package(dep_name, version)
+          # assume the package name is prefixed by a space, a quote or be the first thing on the line
+          # there can be multiple comma-separated versions on the same line with or without quotes
+          # Here are some examples of strings that would be matched:
+          # - aria-query@^5.0.0:
+          # - lodash@^4.17.15, lodash@^4.17.20:
+          # - "@adobe/css-tools@^4.0.1":
+          # - "@babel/runtime@^7.23.1", "@babel/runtime@^7.9.2":
+          /(?:^|[ "])#{Regexp.escape(dep_name)}@#{Regexp.escape(version)}.*?:.*?(\n\n|\z)/m
         end
       end
     end

--- a/sig/package/audit/npm/yarn_lock_parser.rbs
+++ b/sig/package/audit/npm/yarn_lock_parser.rbs
@@ -14,6 +14,8 @@ module Package
         def fetch_package_block: (Symbol, String) -> String
 
         def fetch_package_version: (Symbol, String) -> String
+
+        def regex_pattern_for_package: (Symbol, String) -> Regexp
       end
     end
   end

--- a/test/files/yarn/outdated/package.json
+++ b/test/files/yarn/outdated/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "js-tokens": "^8.0.0"
+    "js-tokens": "8.0.0",
+    "lodash": "^4.17.20",
+    "@testing-library/jest-dom": "6.0.0",
+    "worker-factory": "^7.0.9"
   }
 }

--- a/test/files/yarn/outdated/yarn.lock
+++ b/test/files/yarn/outdated/yarn.lock
@@ -2,7 +2,172 @@
 # yarn lockfile v1
 
 
-js-tokens@^8.0.0:
+"@adobe/css-tools@^4.0.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.1.tgz#abfccb8ca78075a2b6187345c26243c1a0842f28"
+  integrity sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==
+
+"@babel/runtime@^7.23.1", "@babel/runtime@^7.9.2":
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
+  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@testing-library/jest-dom@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.0.0.tgz#d2ba5a3fd13724d5966b3f8cd24d2cedcab4fa76"
+  integrity sha512-Ye2R3+/oM27jir8CzYPmuWdavTaKwNZcu0d22L9pO/vnOYE0wmrtpw79TQJa8H6gV8/i7yd+pLaqeLlA0rTMfg==
+  dependencies:
+    "@adobe/css-tools" "^4.0.1"
+    "@babel/runtime" "^7.9.2"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.5.6"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+aria-query@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+compilerr@^11.0.10:
+  version "11.0.10"
+  resolved "https://registry.yarnpkg.com/compilerr/-/compilerr-11.0.10.tgz#d47291346a651664b04415536e9d6df7867f2b61"
+  integrity sha512-rxZDghSMWwjy+tfs9LZlxjTI4ntPsBoeunopDnPdmkloV0LIHhHKynydbhkI9nzR+IanUR3Dmt/HPB05A9rJ6w==
+  dependencies:
+    "@babel/runtime" "^7.23.1"
+    dashify "^2.0.0"
+    indefinite-article "0.0.2"
+    tslib "^2.6.2"
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
+dashify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dashify/-/dashify-2.0.0.tgz#fff270ca2868ca427fee571de35691d6e437a648"
+  integrity sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==
+
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+dom-accessibility-api@^0.5.6:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+fast-unique-numbers@^8.0.9:
+  version "8.0.9"
+  resolved "https://registry.yarnpkg.com/fast-unique-numbers/-/fast-unique-numbers-8.0.9.tgz#7b832104c74f0b3c6fc4d166feb3e27b5c2156da"
+  integrity sha512-kviaqDPFBYntmhBHWPlncPx7nwyptuU8gipU0c4RlSbbpUp7RLmHPxmPGjFM+Ez3bd0LzXR1vhKjeQU3N/jkqQ==
+  dependencies:
+    "@babel/runtime" "^7.23.1"
+    tslib "^2.6.2"
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+indefinite-article@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/indefinite-article/-/indefinite-article-0.0.2.tgz#4bc855257066cfab61ea68beba75d100d6e2506b"
+  integrity sha512-Au/2XzRkvxq2J6w5uvSSbBKPZ5kzINx5F2wb0SF8xpRL8BP9Lav81TnRbfPp6p+SYjYxwaaLn4EUwI3/MmYKSw==
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+js-tokens@8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-8.0.0.tgz#f068fde9bd2f9f4a24ad78f3b4fa787216b433e3"
-  integrity sha512-3AGrZT6tuMm1ZWWn9mLXh7XMfi2YtiLNPALCVxBCiUVq0LD1OQMxV/AdS/s7rLJU5o9i/jBZw/N4vXXL5dm29A==
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-8.0.0.tgz#5dbe2cdfa9afc93251d3a77bf18c3ad6fa8a4de4"
+  integrity sha512-PC7MzqInq9OqKyTXfIvQNcjMkODJYC8A17kAaQgeW79yfhqTWSOfjHYQ2mDDcwJ96Iibtwkfh0C7R/OvqPlgVA==
+
+lodash@^4.17.15, lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+worker-factory@^7.0.9:
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/worker-factory/-/worker-factory-7.0.12.tgz#58fab20c4112cb4432ec2ead8a8d4d588c14e80c"
+  integrity sha512-1MKEmzrkl5vrLNYwipD3s9OTQHBUE9wpamEuycIy3yKaZmBdf3vkTBEKemn4B8vLv2P8yTJOLVJ5mxpFjeToZg==
+  dependencies:
+    "@babel/runtime" "^7.23.1"
+    compilerr "^11.0.10"
+    fast-unique-numbers "^8.0.9"
+    tslib "^2.6.2"

--- a/test/package/test_audit.rb
+++ b/test/package/test_audit.rb
@@ -97,7 +97,7 @@ module Package
     def test_that_there_is_a_report_of_node_modules_formatted_by_npm_with_no_dependencies
       output = `bundle exec package-audit report test/files/yarn/npm`
 
-      assert_match 'There are no deprecated, outdated or vulnerable node packages!', output
+      assert_match 'Found a total of 1 node packages.', output
     end
 
     def test_that_there_is_a_success_message_when_node_modules_are_up_to_date
@@ -121,13 +121,13 @@ module Package
     def test_that_there_is_a_report_of_node_modules
       output = `bundle exec package-audit report test/files/yarn/report`
 
-      assert_match '1 vulnerable (1 vulnerabilities), 1 outdated, 1 deprecated.', output
+      assert_match '1 vulnerable (1 vulnerabilities), 2 outdated, 1 deprecated.', output
     end
 
     def test_that_there_is_a_message_about_outdated_node_modules
       output = `bundle exec package-audit outdated test/files/yarn/outdated`
 
-      assert_match 'Found a total of 1 node packages.', output
+      assert_match 'Found a total of 2 node packages.', output
     end
 
     def test_that_there_is_a_message_about_deprecated_node_modules


### PR DESCRIPTION
The previous version of the regex incorrectly looked for exact package names preceded by any character which resulted in false matches (e.g. `react-dom@18.2.0` matched `@types/react-dom@18.2.0`). This resulted in a crash when assuming that npmjs.com API would contain the date for a non-existent version of the package. Now the regex requires that the package name be preceded by a space, a quote, or be placed at the very beginning of the line.