### PR TITLE
Fix a rare issue when using `Bundler.definition`.

### DIFF
--- a/lib/package/audit/ruby/gem_collection.rb
+++ b/lib/package/audit/ruby/gem_collection.rb
@@ -31,27 +31,27 @@ module Package
           specs = BundlerSpecs.gemfile(@dir)
           pkgs = specs.map { |spec| Package.new(spec.name, spec.version, Enum::Technology::RUBY) }
           vulnerable_pkgs = VulnerabilityFinder.new(@dir).run
-          pkgs = GemMetaData.new(pkgs + vulnerable_pkgs).fetch.filter(&:risk?)
+          pkgs = GemMetaData.new(@dir, pkgs + vulnerable_pkgs).fetch.filter(&:risk?)
           DuplicatePackageMerger.new(pkgs).run
         end
 
         def deprecated
           specs = BundlerSpecs.gemfile(@dir)
           pkgs = specs.map { |spec| Package.new(spec.name, spec.version, Enum::Technology::RUBY) }
-          pkgs = GemMetaData.new(pkgs).fetch.filter(&:deprecated?)
+          pkgs = GemMetaData.new(@dir, pkgs).fetch.filter(&:deprecated?)
           DuplicatePackageMerger.new(pkgs).run
         end
 
         def outdated(include_implicit: false)
           specs = include_implicit ? BundlerSpecs.all(@dir) : BundlerSpecs.gemfile(@dir)
           pkgs = specs.map { |spec| Package.new(spec.name, spec.version, Enum::Technology::RUBY) }
-          pkgs = GemMetaData.new(pkgs).fetch.filter(&:outdated?)
+          pkgs = GemMetaData.new(@dir, pkgs).fetch.filter(&:outdated?)
           DuplicatePackageMerger.new(pkgs).run
         end
 
         def vulnerable
           pkgs = VulnerabilityFinder.new(@dir).run
-          pkgs = GemMetaData.new(pkgs).fetch.filter(&:vulnerable?)
+          pkgs = GemMetaData.new(@dir, pkgs).fetch.filter(&:vulnerable?)
           DuplicatePackageMerger.new(pkgs).run
         end
       end

--- a/lib/package/audit/ruby/gem_meta_data.rb
+++ b/lib/package/audit/ruby/gem_meta_data.rb
@@ -4,7 +4,8 @@ module Package
   module Audit
     module Ruby
       class GemMetaData
-        def initialize(pkgs)
+        def initialize(dir, pkgs)
+          @dir = dir
           @pkgs = pkgs
           @gem_hash = {}
         end
@@ -45,7 +46,10 @@ module Package
         end
 
         def assign_groups # rubocop:disable Metrics/AbcSize
-          definition = Bundler.definition
+          definition = Bundler.with_unbundled_env do
+            ENV['BUNDLE_GEMFILE'] = "#{@dir}/Gemfile"
+            Bundler.definition
+          end
           groups = definition.groups.uniq.sort
           groups.each do |group|
             specs = definition.specs_for([group])

--- a/sig/package/audit/ruby/gem_meta_data.rbs
+++ b/sig/package/audit/ruby/gem_meta_data.rbs
@@ -2,10 +2,11 @@ module Package
   module Audit
     module Ruby
       class GemMetaData
+        @dir: String
         @gem_hash: Hash[String, Package]
         @pkgs: Array[Package]
 
-        def initialize: (Array[Package]) -> void
+        def initialize: (String, Array[Package]) -> void
 
         def fetch: -> Array[Package]
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -97,31 +97,41 @@
   diagnostics:
   - range:
       start:
-        line: 21
+        line: 22
         character: 25
       end:
-        line: 21
+        line: 22
         character: 36
     severity: WARNING
     message: 'Cannot find the declaration of constant: `SpecFetcher`'
     code: Ruby::UnknownConstant
   - range:
       start:
-        line: 24
+        line: 25
         character: 34
       end:
-        line: 24
+        line: 25
         character: 44
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Dependency`'
     code: Ruby::UnknownConstant
   - range:
       start:
-        line: 48
+        line: 49
         character: 23
       end:
-        line: 48
+        line: 49
         character: 30
+    severity: WARNING
+    message: 'Cannot find the declaration of constant: `Bundler`'
+    code: Ruby::UnknownConstant
+  - range:
+      start:
+        line: 51
+        character: 12
+      end:
+        line: 51
+        character: 19
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Bundler`'
     code: Ruby::UnknownConstant


### PR DESCRIPTION
In rare cases, likely caused by specific versions of other gem dependencies, `Bundler.definition` would point to the wrong Gemfile and produce invalid results. It turns out that before using `Bundler.definition`, Bundler environment needs to be unbundled, and a Gemfile file needs to be specified.