### PR TITLE
Fix an issue with the gem returning an incorrect exit code.

### DIFF
--- a/lib/package/audit/services/command_parser.rb
+++ b/lib/package/audit/services/command_parser.rb
@@ -33,7 +33,7 @@ module Package
           Thread.new do
             all_pkgs, ignored_pkgs = PackageFinder.new(@config, @dir, @report).run(technology)
             ignored_pkgs = [] if @options[Enum::Option::INCLUDE_IGNORED]
-            cumulative_pkgs << all_pkgs
+            cumulative_pkgs += all_pkgs
             sleep 0.1 while technology_index != thread_index # print each technology in order
             mutex.synchronize do
               @spinner.stop
@@ -47,7 +47,7 @@ module Package
         threads.each(&:join)
         @spinner.stop
 
-        cumulative_pkgs.any?
+        cumulative_pkgs.any? ? 1: 0
       end
 
       private

--- a/lib/package/audit/services/command_parser.rb
+++ b/lib/package/audit/services/command_parser.rb
@@ -23,7 +23,7 @@ module Package
         @spinner = Util::Spinner.new('Evaluating packages and their dependencies...')
       end
 
-      def run # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      def run # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         mutex = Mutex.new
         cumulative_pkgs = []
         thread_index = 0
@@ -46,7 +46,7 @@ module Package
         threads.each(&:join)
         @spinner.stop
 
-        cumulative_pkgs.any? ? 1: 0
+        cumulative_pkgs.any? ? 1 : 0
       end
 
       private

--- a/lib/package/audit/services/command_parser.rb
+++ b/lib/package/audit/services/command_parser.rb
@@ -33,7 +33,7 @@ module Package
           Thread.new do
             all_pkgs, ignored_pkgs = PackageFinder.new(@config, @dir, @report).run(technology)
             ignored_pkgs = [] if @options[Enum::Option::INCLUDE_IGNORED]
-            cumulative_pkgs += all_pkgs
+            cumulative_pkgs += all_pkgs || []
             sleep 0.1 while technology_index != thread_index # print each technology in order
             mutex.synchronize do
               @spinner.stop

--- a/sig/package/audit/services/command_parser.rbs
+++ b/sig/package/audit/services/command_parser.rbs
@@ -10,7 +10,7 @@ module Package
 
       def initialize: (String, Hash[String, untyped], Symbol) -> void
 
-      def run: -> bool
+      def run: -> int
 
       private
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -140,7 +140,7 @@
   - range:
       start:
         line: 36
-        character: 31
+        character: 32
       end:
         line: 36
         character: 39

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -135,3 +135,18 @@
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Bundler`'
     code: Ruby::UnknownConstant
+- file: lib/package/audit/services/command_parser.rb
+  diagnostics:
+  - range:
+      start:
+        line: 36
+        character: 31
+      end:
+        line: 36
+        character: 39
+    severity: ERROR
+    message: |-
+      Cannot pass a value of type `(::Array[::Package::Audit::Package] | nil)` as an argument of type `::_ToAry[U(8)]`
+        (::Array[::Package::Audit::Package] | nil) <: ::_ToAry[U(8)]
+          nil <: ::_ToAry[U(8)]
+    code: Ruby::ArgumentTypeMismatch

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -135,18 +135,3 @@
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Bundler`'
     code: Ruby::UnknownConstant
-- file: lib/package/audit/services/command_parser.rb
-  diagnostics:
-  - range:
-      start:
-        line: 36
-        character: 32
-      end:
-        line: 36
-        character: 39
-    severity: ERROR
-    message: |-
-      Cannot pass a value of type `(::Array[::Package::Audit::Package] | nil)` as an argument of type `::_ToAry[U(8)]`
-        (::Array[::Package::Audit::Package] | nil) <: ::_ToAry[U(8)]
-          nil <: ::_ToAry[U(8)]
-    code: Ruby::ArgumentTypeMismatch

--- a/test/package/test_audit.rb
+++ b/test/package/test_audit.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/package/audit/version'
 require 'bundler'
 
 module Package
-  class TestAudit < Minitest::Test
+  class TestAudit < Minitest::Test # rubocop:disable Metrics/ClassLength
     def test_that_it_has_a_version_number
       refute_nil Package::Audit::VERSION
     end
@@ -61,12 +61,14 @@ module Package
 
     def test_that_the_exit_code_is_0_when_report_is_empty
       Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
-      assert_equal true, system('bundle exec package-audit report test/files/gemfile/empty')
+
+      assert system('bundle exec package-audit report test/files/gemfile/empty')
     end
 
     def test_that_the_exit_code_is_1_when_report_is_not_empty
       Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/report/Gemfile' }
-      assert_equal false, system('bundle exec package-audit report test/files/gemfile/report')
+
+      refute system('bundle exec package-audit report test/files/gemfile/report')
     end
 
     def test_that_there_is_a_report_of_gems

--- a/test/package/test_audit.rb
+++ b/test/package/test_audit.rb
@@ -59,6 +59,16 @@ module Package
       assert_match 'There are no deprecated ruby packages!', output
     end
 
+    def test_that_the_exit_code_is_0_when_report_is_empty
+      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
+      assert_equal true, system('bundle exec package-audit report test/files/gemfile/empty')
+    end
+
+    def test_that_the_exit_code_is_1_when_report_is_not_empty
+      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/report/Gemfile' }
+      assert_equal false, system('bundle exec package-audit report test/files/gemfile/report')
+    end
+
     def test_that_there_is_a_report_of_gems
       Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/report/Gemfile' }
       output = `bundle exec package-audit report test/files/gemfile/report`


### PR DESCRIPTION
The exit code was always 0, instead of returning 0 only when there are no packages in the list.

The correct exit code is important for DevOps pipelines.