### PR TITLE
Fix na issue with the loading spinner not disappearing.

### DIFF
--- a/lib/package/audit/services/command_parser.rb
+++ b/lib/package/audit/services/command_parser.rb
@@ -37,7 +37,6 @@ module Package
             sleep 0.1 while technology_index != thread_index # print each technology in order
             mutex.synchronize do
               @spinner.stop
-              print "\r"
               print_results(technology, (all_pkgs || []) - (ignored_pkgs || []), ignored_pkgs || [])
               thread_index += 1
               @spinner.start

--- a/lib/package/audit/util/spinner.rb
+++ b/lib/package/audit/util/spinner.rb
@@ -38,7 +38,7 @@ module Package
         private
 
         def clear_console_line
-          print "\r"
+          print "\r#{' ' * (@message.length + 2)}\r"
         end
       end
     end

--- a/test/package/test_audit.rb
+++ b/test/package/test_audit.rb
@@ -127,7 +127,7 @@ module Package
     def test_that_there_is_a_message_about_outdated_node_modules
       output = `bundle exec package-audit outdated test/files/yarn/outdated`
 
-      assert_match 'Found a total of 2 node packages.', output
+      assert_match 'Found a total of 3 node packages.', output
     end
 
     def test_that_there_is_a_message_about_deprecated_node_modules


### PR DESCRIPTION
Instead of cleaning the console line with `\r`, the proper way to handle it is to pass enough empty spaces into the console to cover up the message that was previously displayed.