### PR TITLE
Cap non-production environment risk to low (was medium).

### DIFF
--- a/lib/package/audit/services/risk_calculator.rb
+++ b/lib/package/audit/services/risk_calculator.rb
@@ -16,7 +16,7 @@ module Package
         unless production_dependency?
           risks.each_with_index do |risk, index|
             risks[index] =
-              [risk, Risk.new(Enum::RiskType::MEDIUM, risk.explanation)].min || Risk.new(Enum::RiskType::NONE)
+              [risk, Risk.new(Enum::RiskType::LOW, risk.explanation)].min || Risk.new(Enum::RiskType::NONE)
           end
         end
         risks

--- a/lib/package/audit/util/summary_printer.rb
+++ b/lib/package/audit/util/summary_printer.rb
@@ -85,7 +85,7 @@ module Package
 
           puts Util::BashColor.blue('5. Check whether the package is used in production or not.')
           puts '   If a package is limited to a non-production environment:'
-          puts "      - cap risk severity to\t -> #{Util::BashColor.orange('medium')} risk"
+          puts "      - cap risk severity to\t -> #{Util::BashColor.yellow('low')} risk"
         end
       end
     end


### PR DESCRIPTION
Development, test, and other non-production environments are typically not included in production builds, and while there is a theoretical risk that the project could be vulnerable due to vulnerabilities in non-production environments, that risk is extremely low.