### PR TITLE
Introduce the environment filter within the CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ gem install package-audit
 * To include only specific technologies use `--technology` or `-t`:
 
     ```bash
-    package-audit -t node --technology ruby [DIR]
+    package-audit -t node -t ruby [DIR]
+    package-audit --technology node --technology ruby [DIR]
+    ```
+
+* To include only specific environments use `--environment` or `-e`:
+
+    ```bash
+    package-audit -e staging -e production [DIR]
+    package-audit --environment staging --environment production [DIR]
     ```
 
 * To show how risk is calculated for the above report run:

--- a/lib/package/audit/cli.rb
+++ b/lib/package/audit/cli.rb
@@ -15,6 +15,9 @@ module Package
       class_option Enum::Option::CONFIG,
                    aliases: '-c', banner: 'FILE',
                    desc: "Path to a custom configuration file, default: #{Const::File::CONFIG})"
+      class_option Enum::Option::ENVIRONMENT,
+                   aliases: '-e', repeatable: true,
+                   desc: 'Environment to be audited (repeat this flag for each environment)'
       class_option Enum::Option::TECHNOLOGY,
                    aliases: '-t', repeatable: true,
                    desc: 'Technology to be audited (repeat this flag for each technology)'

--- a/lib/package/audit/enum/environment.rb
+++ b/lib/package/audit/enum/environment.rb
@@ -2,11 +2,15 @@ module Package
   module Audit
     module Enum
       module Environment
-        DEV = :development
-        TEST = :test
-        STAGING = :staging
-        PRODUCTION = :production
-        DEFAULT = :default
+        DEV = 'development'
+        TEST = 'test'
+        STAGING = 'staging'
+        PRODUCTION = 'production'
+        DEFAULT = 'default'
+
+        def self.all
+          constants.map { |key| Enum::Environment.const_get(key) }.sort
+        end
       end
     end
   end

--- a/lib/package/audit/enum/option.rb
+++ b/lib/package/audit/enum/option.rb
@@ -5,6 +5,7 @@ module Package
         CONFIG = 'config'
         CSV = 'csv'
         CSV_EXCLUDE_HEADERS = 'exclude-headers'
+        ENVIRONMENT = 'environment'
         INCLUDE_IGNORED = 'include-ignored'
         TECHNOLOGY = 'technology'
       end

--- a/lib/package/audit/npm/vulnerability_finder.rb
+++ b/lib/package/audit/npm/vulnerability_finder.rb
@@ -36,7 +36,7 @@ module Package
 
           @vuln_hash[full_name] = Package.new(name, version, 'node') unless @vuln_hash.key? full_name
           @vuln_hash[full_name].update vulnerabilities: @vuln_hash[full_name].vulnerabilities + [vulnerability]
-          @vuln_hash[full_name].update groups: @pkg_hash[parent_name].groups
+          @vuln_hash[full_name].update groups: @pkg_hash[parent_name].groups.map(&:to_s)
         end
       end
     end

--- a/lib/package/audit/npm/yarn_lock_parser.rb
+++ b/lib/package/audit/npm/yarn_lock_parser.rb
@@ -1,3 +1,5 @@
+require_relative '../enum/environment'
+
 module Package
   module Audit
     module Npm
@@ -7,13 +9,17 @@ module Package
           @yarn_lock_path = yarn_lock_path
         end
 
-        def fetch(default_deps, dev_deps)
+        def fetch(default_deps, dev_deps) # rubocop:disable Metrics/MethodLength
           pkgs = []
           default_deps.merge(dev_deps).each do |dep_name, expected_version|
             pkg_block = fetch_package_block(dep_name, expected_version)
             version = fetch_package_version(dep_name, pkg_block)
             pks = Package.new(dep_name.to_s, version, 'node')
-            pks.update groups: dev_deps.key?(dep_name) ? %i[development] : %i[default development]
+            pks.update groups: if dev_deps.key?(dep_name)
+                                 [Enum::Environment::DEV]
+                               else
+                                 [Enum::Environment::DEFAULT, Enum::Environment::DEV]
+                               end
             pkgs << pks
           end
           pkgs

--- a/lib/package/audit/ruby/gem_meta_data.rb
+++ b/lib/package/audit/ruby/gem_meta_data.rb
@@ -45,7 +45,7 @@ module Package
           end
         end
 
-        def assign_groups # rubocop:disable Metrics/AbcSize
+        def assign_groups # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           definition = Bundler.with_unbundled_env do
             ENV['BUNDLE_GEMFILE'] = "#{@dir}/Gemfile"
             Bundler.definition
@@ -54,7 +54,9 @@ module Package
           groups.each do |group|
             specs = definition.specs_for([group])
             specs.each do |spec|
-              @gem_hash[spec.name].update(groups: @gem_hash[spec.name].groups | [group]) if @gem_hash.key? spec.name
+              if @gem_hash.key? spec.name
+                @gem_hash[spec.name].update(groups: (@gem_hash[spec.name].groups | [group]).map(&:to_s))
+              end
             end
           end
         end

--- a/lib/package/audit/services/package_finder.rb
+++ b/lib/package/audit/services/package_finder.rb
@@ -11,16 +11,19 @@ require 'yaml'
 module Package
   module Audit
     class PackageFinder
-      def initialize(config, dir, report)
+      def initialize(config, dir, report, environments)
         @config = config
         @dir = dir
         @report = report
+        @environments = environments
       end
 
       def run(technology)
         all_pkgs = find_by_technology(technology)
-        ignored_pkgs = filter_pkgs_based_on_config(all_pkgs)
-        [all_pkgs, ignored_pkgs]
+        ignored_by_environment_pkgs = filter_pkgs_based_on_environment(all_pkgs)
+        active_pkgs = all_pkgs - ignored_by_environment_pkgs
+        ignored_by_config_pkgs = filter_pkgs_based_on_config(active_pkgs)
+        [active_pkgs, ignored_by_config_pkgs]
       end
 
       private
@@ -50,6 +53,16 @@ module Package
 
         pkgs.each do |pkg|
           ignored_pkgs << pkg if package_filter.ignored?(pkg)
+        end
+        ignored_pkgs
+      end
+
+      def filter_pkgs_based_on_environment(pkgs)
+        ignored_pkgs = []
+
+        pkgs.each do |pkg|
+          puts "#{pkg.name}: #{pkg.groups} - #{@environments}"
+          ignored_pkgs << pkg unless (pkg.groups & @environments).any?
         end
         ignored_pkgs
       end

--- a/sig/package/audit/enum/environment.rbs
+++ b/sig/package/audit/enum/environment.rbs
@@ -2,11 +2,13 @@ module Package
   module Audit
     module Enum
       module Environment
-        DEFAULT: Symbol
-        DEV: Symbol
-        PRODUCTION: Symbol
-        STAGING: Symbol
-        TEST: Symbol
+        DEFAULT: String
+        DEV: String
+        PRODUCTION: String
+        STAGING: String
+        TEST: String
+
+        def self.all: -> Array[String]
       end
     end
   end

--- a/sig/package/audit/enum/option.rbs
+++ b/sig/package/audit/enum/option.rbs
@@ -5,6 +5,7 @@ module Package
         CONFIG: String
         CSV: String
         CSV_EXCLUDE_HEADERS: String
+        ENVIRONMENT: String
         INCLUDE_IGNORED: String
         TECHNOLOGY: String
       end

--- a/sig/package/audit/models/package.rbs
+++ b/sig/package/audit/models/package.rbs
@@ -1,12 +1,12 @@
 module Package
   module Audit
     class Package
-      @groups: Array[Symbol]
+      @groups: Array[String]
       @risks: Array[Risk]
       @technology: String
       @vulnerabilities: Array[String]
 
-      attr_accessor groups: Array[Symbol]
+      attr_accessor groups: Array[String]
       attr_accessor latest_version: String
       attr_accessor latest_version_date: String
       attr_reader name: String

--- a/sig/package/audit/services/command_parser.rbs
+++ b/sig/package/audit/services/command_parser.rbs
@@ -3,6 +3,7 @@ module Package
     class CommandParser
       @config: Hash[String, untyped]?
       @dir: String
+      @environments: Array[String]
       @spinner: Util::Spinner
       @options: Hash[String, untyped]
       @report: Symbol
@@ -17,6 +18,8 @@ module Package
       def learn_more_command: (String) -> String?
 
       def parse_config_file: -> Hash[String, untyped]?
+
+      def parse_environments: -> Array[String]
 
       def parse_technologies: -> Array[String]
 

--- a/sig/package/audit/services/package_finder.rbs
+++ b/sig/package/audit/services/package_finder.rbs
@@ -4,14 +4,17 @@ module Package
       @config: Hash[String, untyped]?
       @dir: String
       @report: Symbol
+      @environments: Array[String]
 
-      def initialize: (Hash[String, untyped]?, String, Symbol) -> void
+      def initialize: (Hash[String, untyped]?, String, Symbol, Array[String]) -> void
 
       def run: (String) -> Array[Array[Package]]
 
       private
 
       def filter_pkgs_based_on_config: (Array[Package]) -> Array[Package]
+
+      def filter_pkgs_based_on_environment: (Array[Package]) -> Array[Package]
 
       def find_by_technology: (String) -> Array[Package]
 

--- a/test/files/gemfile/environments/Gemfile
+++ b/test/files/gemfile/environments/Gemfile
@@ -1,0 +1,17 @@
+source 'https://rubygems.org'
+
+gem 'irb', '1.7.0'
+gem 'rack', '2.2.0.0'
+
+group :development do
+  gem 'reline', '0.3.0'
+  gem 'yard', '0.9.26'
+end
+
+group :test do
+  gem 'minitest', '5.10.0'
+end
+
+group :production do
+  gem 'tzinfo', '1.2.1'
+end

--- a/test/files/gemfile/environments/Gemfile.lock
+++ b/test/files/gemfile/environments/Gemfile.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    io-console (0.5.2)
+    irb (1.7.0)
+      reline (>= 0.3.0)
+    minitest (5.10.0)
+    rack (2.2.0)
+    reline (0.3.0)
+      io-console (~> 0.5)
+    thread_safe (0.3.6)
+    tzinfo (1.2.1)
+      thread_safe (~> 0.1)
+    yard (0.9.26)
+
+PLATFORMS
+  arm64-darwin-22
+  x86_64-darwin-22
+
+DEPENDENCIES
+  irb (= 1.7.0)
+  minitest (= 5.10.0)
+  rack (= 2.2.0.0)
+  reline (= 0.3.0)
+  tzinfo (= 1.2.1)
+  yard (= 0.9.26)
+
+BUNDLED WITH
+   2.4.10

--- a/test/package/audit/test_environment.rb
+++ b/test/package/audit/test_environment.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+require_relative '../../../lib/package/audit/enum/environment'
+
+require 'bundler'
+
+module Package
+  module Audit
+    class TestEnvironment < Minitest::Test
+      def test_that_it_returns_an_error_for_invalid_environments
+        output = `bundle exec package-audit -e invalid`
+
+        assert_match 'ArgumentError: ["invalid"] is not valid list of environments', output
+        assert_match "use one of #{Enum::Environment.all}", output
+      end
+
+      def test_that_no_environment_produces_expected_output
+        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
+        output = `bundle exec package-audit report test/files/gemfile/environments`
+
+        %w[irb minitest rack reline tzinfo yard].each { |pkg| assert_match pkg, output }
+        assert_match 'Found a total of 6 ruby packages.', output
+      end
+
+      def test_that_default_environment_produces_expected_output
+        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
+        output = `bundle exec package-audit report test/files/gemfile/environments -e default`
+
+        %w[irb rack reline].each { |pkg| assert_match pkg, output }
+        assert_match 'Found a total of 3 ruby packages.', output
+      end
+
+      def test_that_development_environment_produces_expected_output
+        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
+        output = `bundle exec package-audit report test/files/gemfile/environments -e development`
+
+        %w[irb rack reline yard].each { |pkg| assert_match pkg, output }
+        assert_match 'Found a total of 4 ruby packages.', output
+      end
+
+      def test_that_test_environment_produces_expected_output
+        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
+        output = `bundle exec package-audit report test/files/gemfile/environments -e test`
+
+        %w[irb minitest rack reline].each { |pkg| assert_match pkg, output }
+        assert_match 'Found a total of 4 ruby packages.', output
+      end
+
+      def test_that_production_environment_produces_expected_output
+        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
+        output = `bundle exec package-audit report test/files/gemfile/environments -e production`
+
+        %w[irb rack reline tzinfo].each { |pkg| assert_match pkg, output }
+        assert_match 'Found a total of 4 ruby packages.', output
+      end
+
+      def test_that_multiple_environments_produces_expected_output
+        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
+        output = `bundle exec package-audit report test/files/gemfile/environments -e test -e production`
+
+        %w[irb minitest rack reline tzinfo].each { |pkg| assert_match pkg, output }
+        assert_match 'Found a total of 5 ruby packages.', output
+      end
+    end
+  end
+end


### PR DESCRIPTION
Environments now use Strings instead of Symbols to simplify comparisons and to be consistent with other enums.

Environment filtering is currently inefficient, as it only occurs after all package metadata have been retrieved instead of pre-filtering the packages based on environments.