### PR TITLE
Fix an issue that produced invalid Bundler spec definitions.

### DIFF
--- a/lib/package/audit/ruby/gem_meta_data.rb
+++ b/lib/package/audit/ruby/gem_meta_data.rb
@@ -48,6 +48,7 @@ module Package
         def assign_groups # rubocop:disable Metrics/AbcSize
           definition = Bundler.with_unbundled_env do
             ENV['BUNDLE_GEMFILE'] = "#{@dir}/Gemfile"
+            Bundler.reset!
             Bundler.definition
           end
           groups = definition.groups.uniq.sort

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -135,3 +135,13 @@
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Bundler`'
     code: Ruby::UnknownConstant
+  - range:
+      start:
+        line: 52
+        character: 12
+      end:
+        line: 52
+        character: 19
+    severity: WARNING
+    message: 'Cannot find the declaration of constant: `Bundler`'
+    code: Ruby::UnknownConstant


### PR DESCRIPTION
When specifying a path to another Ruby project while already being in a Ruby project, gems and gem groups were incorrectly loading from the project from where the script was run instead of using the path of the project to be audited, which was caused by a missing Bundler reset statement. This mismatch caused gems to be assigned to incorrect groups or not be assigned to any groups.