### PR TITLE
Remove the need to do `bundle install` before Ruby auditing.

### DIFF
--- a/lib/package/audit/ruby/gem_meta_data.rb
+++ b/lib/package/audit/ruby/gem_meta_data.rb
@@ -45,12 +45,10 @@ module Package
           end
         end
 
-        def assign_groups # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-          definition = Bundler.with_unbundled_env do
-            ENV['BUNDLE_GEMFILE'] = "#{@dir}/Gemfile"
-            Bundler.reset!
-            Bundler.definition
-          end
+        def assign_groups # rubocop:disable Metrics/AbcSize
+          definition = Bundler::Definition.build Pathname("#{@dir}/Gemfile"), Pathname("#{@dir}/Gemfile.lock"), nil
+          Bundler.ui.level = 'error'
+          definition.resolve_remotely!
           groups = definition.groups.uniq.sort
           groups.each do |group|
             specs = definition.specs_for([group])

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -127,21 +127,11 @@
     code: Ruby::UnknownConstant
   - range:
       start:
-        line: 51
-        character: 12
+        line: 50
+        character: 10
       end:
-        line: 51
-        character: 19
-    severity: WARNING
-    message: 'Cannot find the declaration of constant: `Bundler`'
-    code: Ruby::UnknownConstant
-  - range:
-      start:
-        line: 52
-        character: 12
-      end:
-        line: 52
-        character: 19
+        line: 50
+        character: 17
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Bundler`'
     code: Ruby::UnknownConstant

--- a/test/package/audit/test_environment.rb
+++ b/test/package/audit/test_environment.rb
@@ -14,7 +14,6 @@ module Package
       end
 
       def test_that_no_environment_produces_expected_output
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
         output = `bundle exec package-audit report test/files/gemfile/environments`
 
         %w[irb minitest rack reline tzinfo yard].each { |pkg| assert_match pkg, output }
@@ -22,7 +21,6 @@ module Package
       end
 
       def test_that_default_environment_produces_expected_output
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
         output = `bundle exec package-audit report test/files/gemfile/environments -e default`
 
         %w[irb rack reline].each { |pkg| assert_match pkg, output }
@@ -30,7 +28,6 @@ module Package
       end
 
       def test_that_development_environment_produces_expected_output
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
         output = `bundle exec package-audit report test/files/gemfile/environments -e development`
 
         %w[irb rack reline yard].each { |pkg| assert_match pkg, output }
@@ -38,7 +35,6 @@ module Package
       end
 
       def test_that_test_environment_produces_expected_output
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
         output = `bundle exec package-audit report test/files/gemfile/environments -e test`
 
         %w[irb minitest rack reline].each { |pkg| assert_match pkg, output }
@@ -46,7 +42,6 @@ module Package
       end
 
       def test_that_production_environment_produces_expected_output
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
         output = `bundle exec package-audit report test/files/gemfile/environments -e production`
 
         %w[irb rack reline tzinfo].each { |pkg| assert_match pkg, output }
@@ -54,7 +49,6 @@ module Package
       end
 
       def test_that_multiple_environments_produces_expected_output
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/environments/Gemfile' }
         output = `bundle exec package-audit report test/files/gemfile/environments -e test -e production`
 
         %w[irb minitest rack reline tzinfo].each { |pkg| assert_match pkg, output }

--- a/test/package/audit/test_fields.rb
+++ b/test/package/audit/test_fields.rb
@@ -15,7 +15,6 @@ module Package
       end
 
       def test_that_the_same_fields_are_shown_for_all_reports
-        Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/report/Gemfile' }
         headers = Const::Fields::HEADERS.select { |key, _value| Const::Fields::DEFAULT.include?(key) }
 
         deprecated_output = `bundle exec package-audit deprecated test/files/gemfile/report`

--- a/test/package/test_audit.rb
+++ b/test/package/test_audit.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/package/audit/version'
 require 'bundler'
 
 module Package
-  class TestAudit < Minitest::Test # rubocop:disable Metrics/ClassLength
+  class TestAudit < Minitest::Test
     def test_that_it_has_a_version_number
       refute_nil Package::Audit::VERSION
     end
@@ -32,47 +32,38 @@ module Package
     end
 
     def test_that_there_is_a_success_message_when_report_is_empty
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
       output = `bundle exec package-audit report test/files/gemfile/empty`
 
       assert_match 'There are no deprecated, outdated or vulnerable ruby packages!', output
     end
 
     def test_that_there_is_a_success_message_when_everything_is_up_to_date
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
       output = `bundle exec package-audit outdated test/files/gemfile/empty`
 
       assert_match 'There are no outdated ruby packages!', output
     end
 
     def test_that_there_is_a_success_message_when_there_are_no_vulnerabilities
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
       output = `bundle exec package-audit vulnerable test/files/gemfile/empty`
 
       assert_match 'There are no vulnerable ruby packages!', output
     end
 
     def test_that_there_is_a_success_message_when_there_are_no_deprecations
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
       output = `bundle exec package-audit deprecated test/files/gemfile/empty`
 
       assert_match 'There are no deprecated ruby packages!', output
     end
 
     def test_that_the_exit_code_is_0_when_report_is_empty
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/empty/Gemfile' }
-
       assert system('bundle exec package-audit report test/files/gemfile/empty')
     end
 
     def test_that_the_exit_code_is_1_when_report_is_not_empty
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/report/Gemfile' }
-
       refute system('bundle exec package-audit report test/files/gemfile/report')
     end
 
     def test_that_there_is_a_report_of_gems
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/report/Gemfile' }
       output = `bundle exec package-audit report test/files/gemfile/report`
 
       assert_match 'Found a total of 3 ruby packages.', output
@@ -80,21 +71,18 @@ module Package
     end
 
     def test_that_there_is_a_message_about_outdated_gems
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/outdated/Gemfile' }
       output = `bundle exec package-audit outdated test/files/gemfile/outdated`
 
       assert_match 'Found a total of 1 ruby packages.', output
     end
 
     def test_that_there_is_a_message_about_deprecated_gems
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/deprecated/Gemfile' }
       output = `bundle exec package-audit deprecated test/files/gemfile/deprecated`
 
       assert_match 'Found a total of 1 ruby packages.', output
     end
 
     def test_that_there_is_a_message_about_vulnerable_gems
-      Bundler.with_unbundled_env { system 'bundle install --quiet --gemfile=test/files/gemfile/vulnerable/Gemfile' }
       output = `bundle exec package-audit vulnerable test/files/gemfile/vulnerable`
 
       assert_match 'Found a total of 1 ruby packages.', output


### PR DESCRIPTION
Ruby gems are now resolved remotely and instead of locally, which eliminates the annoying requirements to have the gems be installed locally and potentially having to install a new Ruby version and struggle with the installation of gems with native extension.