### PR TITLE
Remove Bundler warning about an old bundler gem version.

### DIFF
--- a/lib/package/audit/const/cmd.rb
+++ b/lib/package/audit/const/cmd.rb
@@ -3,7 +3,7 @@ module Package
     module Const
       module Cmd
         BUNDLE_AUDIT = 'bundle-audit check --update'
-        BUNDLE_AUDIT_JSON = 'bundle-audit check --update --quiet --format json %s'
+        BUNDLE_AUDIT_JSON = 'bundle-audit check --update --quiet --format json %s 2>/dev/null'
 
         NPM_AUDIT = 'npm audit'
         NPM_AUDIT_JSON = 'npm audit --json'

--- a/lib/package/audit/ruby/bundler_specs.rb
+++ b/lib/package/audit/ruby/bundler_specs.rb
@@ -18,6 +18,7 @@ module Package
         def self.gemfile(dir)
           current_dependencies = Bundler.with_unbundled_env do
             ENV['BUNDLE_GEMFILE'] = "#{dir}/Gemfile"
+            Bundler.ui.level = 'error'
             Bundler.reset!
             Bundler.ui.silence do
               Bundler.load.dependencies.to_h { |dep| [dep.name, dep] }

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -86,9 +86,19 @@
   - range:
       start:
         line: 23
-        character: 14
+        character: 12
       end:
         line: 23
+        character: 19
+    severity: WARNING
+    message: 'Cannot find the declaration of constant: `Bundler`'
+    code: Ruby::UnknownConstant
+  - range:
+      start:
+        line: 24
+        character: 14
+      end:
+        line: 24
         character: 21
     severity: WARNING
     message: 'Cannot find the declaration of constant: `Bundler`'


### PR DESCRIPTION
Previously, the following warning would be generated if the installed bundler gem version is older than that within Gemfile.lock:

Evaluating packages and their dependencies... -Warning: the running version of Bundler (2.1.4) is older than the version that created the lockfile (2.3.8). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.8`.