### PR TITLE
Fix an issue that displayed packages ignored by config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ technology:
 
 **Note:** If the installed package version differs from the expected package version specified in the configuration file, the exclusion settings will not apply to that particular package.
 
+**Note:** If a package is reported for multiple reasons (e.g. vulnerable and outdated), it will still be reported unless the exclusion criteria match every reason for being on the report.
+
 > By design, wildcard (`*`) version exclusions are not supported to prevent developers from inadvertently overlooking crucial messages when packages are updated.
 
 ## Development

--- a/lib/package/audit/services/package_filter.rb
+++ b/lib/package/audit/services/package_filter.rb
@@ -9,7 +9,8 @@ require 'yaml'
 module Package
   module Audit
     class PackageFilter
-      def initialize(config)
+      def initialize(report, config)
+        @report = report
         @config = config
       end
 
@@ -30,9 +31,28 @@ module Package
       end
 
       def ignore_package?(pkg, yaml)
-        (!pkg.deprecated? || yaml&.dig(Const::YAML::DEPRECATED) == false) &&
-          (!pkg.outdated? || yaml&.dig(Const::YAML::OUTDATED) == false) &&
-          (!pkg.vulnerable? || yaml&.dig(Const::YAML::VULNERABLE) == false)
+        case @report
+        when Enum::Report::DEPRECATED
+          ignore_deprecated?(pkg, yaml)
+        when Enum::Report::OUTDATED
+          ignore_outdated?(pkg, yaml)
+        when Enum::Report::VULNERABLE
+          ignore_vulnerable?(pkg, yaml)
+        else
+          ignore_deprecated?(pkg, yaml) && ignore_outdated?(pkg, yaml) && ignore_vulnerable?(pkg, yaml)
+        end
+      end
+
+      def ignore_deprecated?(pkg, yaml)
+        !pkg.deprecated? || yaml&.dig(Const::YAML::DEPRECATED) == false
+      end
+
+      def ignore_outdated?(pkg, yaml)
+        !pkg.outdated? || yaml&.dig(Const::YAML::OUTDATED) == false
+      end
+
+      def ignore_vulnerable?(pkg, yaml)
+        !pkg.vulnerable? || yaml&.dig(Const::YAML::VULNERABLE) == false
       end
     end
   end

--- a/lib/package/audit/services/package_finder.rb
+++ b/lib/package/audit/services/package_finder.rb
@@ -48,7 +48,7 @@ module Package
       end
 
       def filter_pkgs_based_on_config(pkgs)
-        package_filter = PackageFilter.new(@config)
+        package_filter = PackageFilter.new(@report, @config)
         ignored_pkgs = []
 
         pkgs.each do |pkg|

--- a/sig/package/audit/services/package_filter.rbs
+++ b/sig/package/audit/services/package_filter.rbs
@@ -2,14 +2,21 @@ module Package
   module Audit
     class PackageFilter
       @config: Hash[String, untyped]?
+      @report: Symbol
 
-      def initialize: (Hash[String, untyped]?) -> void
+      def initialize: (Symbol, Hash[String, untyped]?) -> void
 
       def ignored?: (Package) -> bool
 
       private
 
+      def ignore_deprecated?: (Package, Hash[String, untyped]?) -> bool
+
+      def ignore_outdated?: (Package, Hash[String, untyped]?) -> bool
+
       def ignore_package?: (Package, Hash[String, untyped]?) -> bool
+
+      def ignore_vulnerable?: (Package, Hash[String, untyped]?) -> bool
 
       def pkg_version_in_config?: (Package, Hash[String, untyped]?) -> bool
 

--- a/test/package/audit/services/test_package_filter.rb
+++ b/test/package/audit/services/test_package_filter.rb
@@ -5,36 +5,47 @@ module Package
   module Audit
     class TestPackageFilter < Minitest::Test
       def setup
-        config = YAML.load_file('test/files/config/.package-audit.yml')
-        @filter = PackageFilter.new(config)
+        @config = YAML.load_file('test/files/config/.package-audit.yml')
       end
 
       def test_that_outdated_packaged_are_ignored
+        filter = PackageFilter.new(Enum::Report::ALL, @config)
         @pkg1 = Package.new('test', '0.30.0', Enum::Technology::RUBY, latest_version: '0.30.2')
         @pkg2 = Package.new('test', '0.30.1', Enum::Technology::RUBY, latest_version: '0.30.2')
 
         assert_predicate @pkg1, :outdated?
-        assert @filter.ignored?(@pkg1)
+        assert filter.ignored?(@pkg1)
         assert_predicate @pkg2, :outdated?
-        refute @filter.ignored?(@pkg2)
+        refute filter.ignored?(@pkg2)
       end
 
       def test_that_deprecated_packaged_are_ignored
+        filter = PackageFilter.new(Enum::Report::ALL, @config)
         @pkg1 = Package.new('test', '0.30.0', Enum::Technology::RUBY, latest_version_date: '2020-01-01')
         @pkg2 = Package.new('test', '0.30.1', Enum::Technology::RUBY, latest_version_date: '2020-01-01')
 
         assert_predicate @pkg1, :deprecated?
-        assert @filter.ignored?(@pkg1)
+        assert filter.ignored?(@pkg1)
         assert_predicate @pkg2, :deprecated?
-        refute @filter.ignored?(@pkg2)
+        refute filter.ignored?(@pkg2)
       end
 
       def test_that_outdated_packages_are_not_ignored_if_deprecated
+        filter = PackageFilter.new(Enum::Report::ALL, @config)
         @pkg = Package.new('test2', '1.0.0', Enum::Technology::RUBY, latest_version: '1.0.1')
 
         assert_predicate @pkg, :outdated?
         assert_predicate @pkg, :deprecated?
-        refute @filter.ignored?(@pkg)
+        refute filter.ignored?(@pkg)
+      end
+
+      def test_that_outdated_packaged_are_ignored_when_report_is_outdated
+        filter = PackageFilter.new(Enum::Report::OUTDATED, @config)
+        @pkg = Package.new('test2', '1.0.0', Enum::Technology::RUBY, latest_version: '1.0.1')
+
+        assert_predicate @pkg, :outdated?
+        assert_predicate @pkg, :deprecated?
+        assert filter.ignored?(@pkg)
       end
     end
   end


### PR DESCRIPTION
For example, if a package is vulnerable and outdated at the same time, and there is vulnerability exclusion rule, it should only show up on the general report (because there is no outdated exclusion rule), but be excluded from the vulnerability report.