### PR TITLE
Ship only runtime files in the published gem

### DIFF
--- a/package-audit.gemspec
+++ b/package-audit.gemspec
@@ -15,13 +15,14 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/vkononov/package-audit'
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  gemspec = File.basename(__FILE__)
+  # Ship only what the gem needs at runtime: the executable and library code
+  # plus the license and readme. Using an allowlist keeps tests, tooling, CI
+  # config, and other development files out of the package even as new ones
+  # are added over time.
+  root_files = %w[LICENSE.txt README.md]
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ docs/ test/ .git .github .rubocop.yml Gemfile Rakefile])
+    ls.readlines("\x0", chomp: true).select do |f|
+      f.start_with?('exe/', 'lib/') || root_files.include?(f)
     end
   end
   spec.bindir = 'exe'


### PR DESCRIPTION
Replace the exclusion list with an allowlist so the released gem contains just the executable, library code, license, and readme. This keeps tests, tooling, and CI config out of the package even as new development files are added over time.