### PR TITLE
Add single status checks to summarise CI matrices

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,3 +20,15 @@ jobs:
           bundler-cache: true
       - name: Run Rubocop
         run: bin/lint --no-fix
+
+  # Single stable status check that summarises the job above, so branch
+  # protection can require one name ("Lint") that stays valid as it changes.
+  lint-result:
+    name: Lint
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if the lint job did not succeed
+        if: needs.test.result != 'success'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,15 @@ jobs:
         run: bundle install
       - name: Run tests
         run: bundle exec rake test
+
+  # Single stable status check that summarises the whole matrix above, so
+  # branch protection can require one name ("Test") instead of every cell.
+  test-result:
+    name: Test
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any matrix job did not succeed
+        if: needs.test.result != 'success'
+        run: exit 1


### PR DESCRIPTION
Each workflow now ends with one aggregate job that passes only if the whole job set succeeded, giving a stable check name ("Test", "Lint") to require in branch protection instead of listing every Ruby version by hand, which broke whenever the matrix changed.