### PR TITLE
Stop hard-coding the vulnerability count in report test

### DIFF
--- a/test/package/test_audit.rb
+++ b/test/package/test_audit.rb
@@ -60,7 +60,7 @@ module Package
       output = `bundle exec package-audit test/files/gemfile/report`
 
       assert_match 'Found a total of 3 Ruby packages.', output
-      assert_match '1 ⦗V⦘ulnerable (24 vulnerabilities), 2 ⦗O⦘utdated, 1 ⦗D⦘eprecated.', output
+      assert_match(/1 ⦗V⦘ulnerable \(\d+ vulnerabilities\), 2 ⦗O⦘utdated, 1 ⦗D⦘eprecated\./, output)
     end
 
     def test_that_there_is_a_message_about_outdated_gems


### PR DESCRIPTION
The report test asserted an exact number of vulnerabilities, but that count comes from the live advisory database and grows over time, so the test broke as new advisories were published. Match any count with a pattern instead, matching what the Node report test already does, since the test only cares that one package is flagged as vulnerable.