### PR TITLE
Fix broken interactive console command

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'bundler/setup'
-require 'package/audit'
+require 'package/audit/cli'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
The console script tried to load a file that does not exist, so it failed to start. It now loads the actual entry point.