### PR TITLE
Include the example image in the published gem

### DIFF
--- a/package-audit.gemspec
+++ b/package-audit.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/vkononov/package-audit'
 
   # Ship only what the gem needs at runtime: the executable and library code
-  # plus the license and readme. Using an allowlist keeps tests, tooling, CI
-  # config, and other development files out of the package even as new ones
-  # are added over time.
+  # plus the license, readme, and the images the readme references. Using an
+  # allowlist keeps tests, tooling, CI config, and other development files out
+  # of the package even as new ones are added over time.
   root_files = %w[LICENSE.txt README.md]
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).select do |f|
-      f.start_with?('exe/', 'lib/') || root_files.include?(f)
+      f.start_with?('exe/', 'lib/', 'docs/') || root_files.include?(f)
     end
   end
   spec.bindir = 'exe'

--- a/test/package/test_gemspec.rb
+++ b/test/package/test_gemspec.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Package
+  module Audit
+    class TestGemspec < Minitest::Test
+      GEMSPEC_PATH = File.expand_path('../../package-audit.gemspec', __dir__)
+      README_PATH = File.expand_path('../../README.md', __dir__)
+
+      def setup
+        @spec = Gem::Specification.load(GEMSPEC_PATH)
+      end
+
+      def test_that_readme_referenced_images_are_packaged
+        local_images = File.read(README_PATH)
+                           .scan(/!\[[^\]]*\]\(([^)]+)\)/).flatten
+                           .reject { |path| path.start_with?('http://', 'https://') }
+
+        refute_empty local_images, 'Expected the README to reference at least one local image'
+
+        local_images.each do |path|
+          assert_includes @spec.files, path,
+                          "README references '#{path}' but it is not included in the packaged gem"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The readme's screenshot lives under the docs folder, which was left out of the package, so the image was missing wherever the gem was used outside the source repo. The docs files are now shipped with the gem.