### PR TITLE
Replace broken yarn audit with npm bulk advisories

### DIFF
--- a/lib/package/audit/const/cmd.rb
+++ b/lib/package/audit/const/cmd.rb
@@ -6,10 +6,6 @@ module Package
         BUNDLE_AUDIT_JSON = 'bundle-audit check --update --quiet --format json "%s" 2>/dev/null'
 
         NPM_AUDIT = 'npm audit'
-        NPM_AUDIT_JSON = 'npm audit --json'
-
-        YARN_AUDIT = 'yarn audit'
-        YARN_AUDIT_JSON = 'yarn audit --json --cwd "%s"'
       end
     end
   end

--- a/lib/package/audit/npm/vulnerability_finder.rb
+++ b/lib/package/audit/npm/vulnerability_finder.rb
@@ -1,13 +1,18 @@
-require 'open3'
+require 'json'
+require 'net/http'
+require 'openssl'
 
-require_relative '../const/cmd'
+require_relative '../const/file'
 require_relative '../enum/vulnerability_type'
 
 module Package
   module Audit
     module Npm
-      class VulnerabilityFinder
-        AUDIT_ADVISORY_REGEX = /^{"type":"auditAdvisory".*$/
+      class VulnerabilityFinder # rubocop:disable Metrics/ClassLength
+        BULK_ADVISORY_URL = 'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk'
+        BATCH_SIZE = 100
+        TIMEOUT = 30
+        VERSION_LINE = /^\s+"?version"?\s+"([^"]+)"/
 
         def initialize(dir, pkgs)
           @dir = dir
@@ -16,48 +21,142 @@ module Package
         end
 
         def run
-          # Suppress Node.js url.parse deprecation warnings from yarn audit command
-          command = format(Const::Cmd::YARN_AUDIT_JSON, @dir)
-          env_vars = { 'NODE_NO_WARNINGS' => '1' }
+          versions_by_name = collect_versions_by_name
+          return [] if versions_by_name.empty?
 
-          json_string_lines, = Open3.capture3(env_vars, command)
-          array = json_string_lines.scan(AUDIT_ADVISORY_REGEX)
-
-          vulnerability_json_array = JSON.parse("[#{array.join(',')}]", symbolize_names: true)
-          vulnerability_json_array.each do |vulnerability_json|
-            update_meta_data(vulnerability_json)
+          versions_by_name.each_slice(BATCH_SIZE) do |batch|
+            batch_versions = batch.to_h
+            fetch_advisories(batch_versions).each do |name, advisories|
+              package_name = name.to_s
+              apply_advisories(package_name, Array(advisories), batch_versions[package_name] || [])
+            end
           end
+
           @vuln_hash.values
         end
 
         private
 
-        def update_meta_data(json)
-          resolution_path = json.dig(:data, :resolution, :path)
-          return unless resolution_path # Skip if no resolution path (private package)
+        def collect_versions_by_name
+          versions_by_name = {}
 
-          parent_name = resolution_path.split('>').first
-          advisory = json[:data][:advisory]
-          package_info = extract_package_info(advisory)
-          update_vulnerability_info(package_info, parent_name, advisory[:severity])
+          (lockfile_packages + @pkg_hash.values.map { |pkg| [pkg.name, pkg.version] }).each do |name, version|
+            next if version.to_s.empty? || version == 'unknown'
+
+            versions = versions_by_name[name] ||= []
+            versions << version unless versions.include?(version)
+          end
+
+          versions_by_name
         end
 
-        def extract_package_info(advisory)
-          {
-            name: advisory[:module_name],
-            version: advisory[:findings][0][:version]
-          }
+        def lockfile_packages
+          path = "#{@dir}/#{Const::File::YARN_LOCK}"
+          return [] unless File.exist?(path)
+
+          packages = []
+          current_names = []
+          File.foreach(path) do |line|
+            current_names, packages = process_lockfile_line(line, current_names, packages)
+          end
+          packages
         end
 
-        def update_vulnerability_info(package_info, parent_name, severity)
-          name = package_info[:name]
-          version = package_info[:version]
+        def process_lockfile_line(line, current_names, packages)
+          if lockfile_key_line?(line)
+            [package_names_from_lock_key(line.strip.chomp(':')), packages]
+          elsif (match = line.match(VERSION_LINE))
+            match_version = match[1]
+            current_names.each { |name| packages << [name, match_version] }
+            [[], packages]
+          else
+            [current_names, packages]
+          end
+        end
+
+        def lockfile_key_line?(line)
+          line.match?(/^\S/) && line.include?('@') && line.strip.end_with?(':')
+        end
+
+        def package_names_from_lock_key(key)
+          key.split(',').map do |entry|
+            package_name_from_spec(entry.strip.gsub(/\A["']|["']\z/, ''))
+          end.uniq
+        end
+
+        def package_name_from_spec(spec)
+          if spec.start_with?('@')
+            "@#{spec.split('@', 3)[1]}"
+          else
+            spec.split('@', 2).first
+          end
+        end
+
+        def fetch_advisories(versions_by_name)
+          uri = URI(BULK_ADVISORY_URL)
+          response = make_request(uri, versions_by_name.to_json)
+          unless response.is_a?(Net::HTTPSuccess)
+            warn "Warning: Unable to fetch npm advisories (#{response.code} #{response.message})."
+            return {}
+          end
+
+          JSON.parse(response.body)
+        rescue StandardError => e
+          warn "Warning: Error while fetching npm advisories: #{e.message}"
+          {}
+        end
+
+        def make_request(uri, body)
+          request = Net::HTTP::Post.new(uri)
+          request['Content-Type'] = 'application/json'
+          request['Accept'] = 'application/json'
+          request.body = body
+          create_http_client(uri).request(request)
+        end
+
+        def create_http_client(uri)
+          Net::HTTP.new(uri.host, uri.port).tap do |http|
+            http.use_ssl = true
+            http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+            http.cert_store = OpenSSL::X509::Store.new
+            http.cert_store.set_default_paths
+            http.read_timeout = TIMEOUT
+            http.open_timeout = TIMEOUT
+          end
+        end
+
+        def apply_advisories(name, advisories, versions)
+          advisories.each do |advisory|
+            Array(versions).each do |version|
+              next unless version_matches?(version, advisory['vulnerable_versions'])
+
+              update_vulnerability_info(name, version, advisory['severity'])
+            end
+          end
+        end
+
+        def version_matches?(version, vulnerable_versions)
+          return true if vulnerable_versions.nil? || vulnerable_versions.empty?
+
+          vulnerable_versions.split(/\s*\|\|\s*/).any? do |range|
+            requirements = range.split(/\s+/).reject(&:empty?)
+            next true if requirements.empty?
+
+            Gem::Requirement.new(*requirements).satisfied_by?(Gem::Version.new(version))
+          rescue ArgumentError
+            true
+          end
+        end
+
+        def update_vulnerability_info(name, version, severity)
           full_name = "#{name}@#{version}"
           vulnerability = severity || Enum::VulnerabilityType::UNKNOWN
 
           @vuln_hash[full_name] ||= Package.new(name, version, 'node')
-          @vuln_hash[full_name].update vulnerabilities: @vuln_hash[full_name].vulnerabilities + [vulnerability]
-          @vuln_hash[full_name].update groups: @pkg_hash[parent_name]&.groups&.map(&:to_s) || []
+          @vuln_hash[full_name].update(
+            vulnerabilities: @vuln_hash[full_name].vulnerabilities + [vulnerability],
+            groups: @pkg_hash[name]&.groups&.map(&:to_s) || []
+          )
         end
       end
     end

--- a/lib/package/audit/services/command_parser.rb
+++ b/lib/package/audit/services/command_parser.rb
@@ -140,7 +140,7 @@ module Package
         when Enum::Technology::RUBY
           Const::Cmd::BUNDLE_AUDIT
         when Enum::Technology::NODE
-          Const::Cmd::YARN_AUDIT
+          Const::Cmd::NPM_AUDIT
         else
           raise ArgumentError, "Unexpected technology \"#{technology}\" found in #{__method__}"
         end


### PR DESCRIPTION
Yarn Classic's audit API was retired, so Node vulnerability checks stopped returning results and the daily CI failed. Query npm's bulk advisory endpoint from the lockfile instead.